### PR TITLE
Remove `.autoStartup(false)` configuration

### DIFF
--- a/spring-cloud-starter-stream-sink-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkConfiguration.java
@@ -24,13 +24,10 @@ import org.springframework.cloud.stream.app.ftp.FtpSessionFactoryConfiguration;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.integration.dsl.GenericEndpointSpec;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.ftp.Ftp;
 import org.springframework.integration.dsl.ftp.FtpMessageHandlerSpec;
-import org.springframework.integration.dsl.support.Consumer;
-import org.springframework.integration.file.remote.handler.FileTransferringMessageHandler;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
 
@@ -57,13 +54,7 @@ public class FtpSinkConfiguration {
 			handlerSpec.fileNameExpression(properties.getFilenameExpression().getExpressionString());
 		}
 		return IntegrationFlows.from(Sink.INPUT)
-			.handle(handlerSpec,
-				new Consumer<GenericEndpointSpec<FileTransferringMessageHandler<FTPFile>>>() {
-					@Override
-					public void accept(GenericEndpointSpec<FileTransferringMessageHandler<FTPFile>> e) {
-						e.autoStartup(false);
-					}
-				})
+			.handle(handlerSpec)
 			.get();
 	}
 


### PR DESCRIPTION
A new Spring Cloud Stream version doesn't manipulate lifecycles manually any more.
Everything relies on the standard ApplicationContext environment.
Therefore all the endpoints should be in the `.autoStartup(true)` (default) to be started automatically by the ApplicationContext