### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpSinkTestConfiguration.java
+++ b/ftp-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpSinkTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpSourceTestConfiguration.java
+++ b/ftp-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpSourceTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ftp-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpTestSupport.java
+++ b/ftp-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/ftp/FtpTestSupport.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkIntegrationTests.java
+++ b/spring-cloud-starter-stream-sink-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-sink-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkPropertiesTests.java
+++ b/spring-cloud-starter-stream-sink-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/sink/FtpSinkPropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceProperties.java
+++ b/spring-cloud-starter-stream-source-ftp/src/main/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/source/FtpSourceIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-source-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/source/FtpSourcePropertiesTests.java
+++ b/spring-cloud-starter-stream-source-ftp/src/test/java/org/springframework/cloud/stream/app/ftp/source/FtpSourcePropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 12 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).